### PR TITLE
Add Multiple Region Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,31 @@ GET /admin/thread/list?q=&limit=10&offset=&key_id=&session_id=
 Authorization: Bearer br_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
+
+
+Update Config Region
+
+```text
+POST /admin/config/region
+Content-Type: application/json
+Authorization: Bearer br_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+{
+	"region":"us-east-1,us-west-2"
+}
+```
+
+List Config Region
+
+```text
+GET /admin/config/region
+Authorization: Bearer br_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+
+
+
+
 ### User API
 
 My sessions

--- a/src/controller/admin/ConfigController.ts
+++ b/src/controller/admin/ConfigController.ts
@@ -1,0 +1,27 @@
+import config from '../../config';
+import helper from "../../util/helper"
+import AbstractController from "../AbstractController";
+
+class ConfigController extends AbstractController {
+    public routers(router: import("koa-router") <any, {}>): void {
+        router.get("/admin/config/region", this.getRegionConfig);
+        router.post("/admin/config/region", this.updateRegionConfig);
+    }
+
+    async getRegionConfig(ctx: any) {
+        return super.ok(ctx, {"region":config.bedrock.region,"random_region":helper.selectRandomRegion(config.bedrock.region)});
+    }
+
+    async  updateRegionConfig(ctx: any) {
+        const data = ctx.request.body;
+        if(data?.region){
+            config.bedrock.region=data.region
+        }
+        return super.ok(ctx, data);
+    }
+
+}
+
+
+
+export default (router: any) => new ConfigController(router);

--- a/src/providers/bedrock_claude.ts
+++ b/src/providers/bedrock_claude.ts
@@ -5,6 +5,7 @@ import {
     InvokeModelWithResponseStreamCommand,
 } from "@aws-sdk/client-bedrock-runtime";
 import config from '../config';
+import helper from "../util/helper";
 import WebResponse from "../util/response";
 import AbstractProvider from "./abstract_provider";
 import ChatMessageConverter from './chat_message'
@@ -16,7 +17,7 @@ export default class BedrockClaude extends AbstractProvider {
     chatMessageConverter: ChatMessageConverter;
     constructor() {
         super();
-        this.client = new BedrockRuntimeClient({ region: config.bedrock.region });
+        this.client = new BedrockRuntimeClient({ region: helper.selectRandomRegion(config.bedrock.region) });
         this.chatMessageConverter = new ChatMessageConverter();
     }
 

--- a/src/providers/bedrock_knowledge_base.ts
+++ b/src/providers/bedrock_knowledge_base.ts
@@ -30,8 +30,8 @@ export default class BedrockKnowledgeBase extends AbstractProvider {
     // console.log(chatRequest);
     const { messages, stream, config } = chatRequest;
     if (!this.client) {
-      this.client = new BedrockRuntimeClient({ region: config.region || sysConfig.bedrock.region });
-      this.clientAgent = new BedrockAgentRuntimeClient({ region: config.region || sysConfig.bedrock.region });
+      this.client = new BedrockRuntimeClient({ region: config.region || helper.selectRandomRegion(sysConfig.bedrock.region) });
+      this.clientAgent = new BedrockAgentRuntimeClient({ region: config.region || helper.selectRandomRegion(sysConfig.bedrock.region)});
     }
 
     const lastMsg = messages.pop();

--- a/src/providers/bedrock_llama3.ts
+++ b/src/providers/bedrock_llama3.ts
@@ -2,6 +2,7 @@ import { ChatRequest, ResponseData } from "../entity/chat_request";
 import AbstractProvider from "./abstract_provider";
 import ChatMessageConverter from './chat_message';
 import config from '../config';
+import helper from "../util/helper";
 import WebResponse from "../util/response";
 
 import {
@@ -18,7 +19,7 @@ export default class BedrockLlama3 extends AbstractProvider {
     chatMessageConverter: ChatMessageConverter;
     constructor() {
         super();
-        this.client = new BedrockRuntimeClient({ region: config.bedrock.region });
+        this.client = new BedrockRuntimeClient({ region: helper.selectRandomRegion(config.bedrock.region) });
         this.chatMessageConverter = new ChatMessageConverter();
     }
 

--- a/src/providers/bedrock_mixtral.ts
+++ b/src/providers/bedrock_mixtral.ts
@@ -3,6 +3,7 @@ import AbstractProvider from "./abstract_provider";
 import ChatMessageConverter from './chat_message';
 
 import config from '../config';
+import helper from "../util/helper";
 import WebResponse from "../util/response";
 
 import {
@@ -19,7 +20,7 @@ export default class BedrockMixtral extends AbstractProvider {
     chatMessageConverter: ChatMessageConverter;
     constructor() {
         super();
-        this.client = new BedrockRuntimeClient({ region: config.bedrock.region });
+        this.client = new BedrockRuntimeClient({ region: helper.selectRandomRegion(config.bedrock.region) });
         this.chatMessageConverter = new ChatMessageConverter();
     }
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -10,6 +10,9 @@ import admin_model_controller from './controller/admin/ModelController';
 import user_session_controller from './controller/user/SessionController';
 import user_thread_controller from './controller/user/ThreadController';
 import user_key_controller from './controller/user/KeyController';
+
+import admin_config_controller from './controller/admin/ConfigController';
+
 // import user_thread from './controller/user/thread';
 
 export const router = new Router();
@@ -25,6 +28,7 @@ admin_payment_controller(router);
 admin_session_controller(router);
 admin_thread_controller(router);
 admin_model_controller(router);
+admin_config_controller(router);
 
 // User APIs
 user_session_controller(router);

--- a/src/util/helper.ts
+++ b/src/util/helper.ts
@@ -40,7 +40,7 @@ const helper = {
         return null;
     },
     refineModelParameters: async (chatRequest: ChatRequest, ctx: any) => {
-        const region = chatRequest.config?.region || config.bedrock.region;
+        const region = chatRequest.config?.region || helper.selectRandomRegion(config.bedrock.region);
         switch (chatRequest.model) {
             case 'claude-3-sonnet':
                 chatRequest.model_id = "anthropic.claude-3-sonnet-20240229-v1:0";
@@ -215,7 +215,24 @@ const helper = {
 
             console.log("Message sent: %s", info.messageId);
         }
-    }
+    },
+    
+    selectRandomRegion: (regionString: string) => {
+        const regions = regionString.split(',').map(region => region.trim());
+        let selectRegion = ""
+        if (regions.length === 1) {
+            selectRegion = regions[0]
+        }
+        const randomIndex = Math.floor(Math.random() * regions.length);
+        selectRegion= regions[randomIndex]
+        
+        if (config.debugMode){
+            console.log(`[selectRandomRegion]: isMultipleRegion: ${regions.length >1}, ${selectRegion}`)
+        }
+
+        return selectRegion; 
+        
+      }
 }
 
 export default helper;


### PR DESCRIPTION
*Issue #, if available:*
Add multiple region support , now we can use "us-east-1,us-west-2" region list and connector use random region from list when you invoke the model.

```bash
#you need update region list through Admin API /admin/config/region

POST /admin/config/region
Content-Type: application/json
Authorization: Bearer br_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

{
	"region":"us-east-1,us-west-2"
}

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
