### PR TITLE
Add  ollama backend support

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "koa-router": "^12.0.1",
     "koa-static-server": "^1.5.2",
     "nodemailer": "^6.9.13",
+    "ollama": "^0.5.1",
     "pg": "^8.11.3",
     "winston": "^3.13.0"
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,9 @@ export default {
         aws_secret_key: process.env.AWS_SECRET_ACCESS_KEY,
         region: process.env.AWS_DEFAULT_REGION || "us-east-1"
     },
+    ollama:{
+        host : process.env.OLLAMA_HOST||"http://localhost:11434"
+    },
     admin_api_key: process.env.ADMIN_API_KEY,
     debugMode: process.env.DEBUG_MODE || false, // set DEBUG_MODE=<empty> to disable
     disableUI: process.env.DISABLE_UI || false,

--- a/src/providers/ollama_provider.ts
+++ b/src/providers/ollama_provider.ts
@@ -63,11 +63,15 @@ export default class OllamaAProvider extends AbstractProvider {
                 options
             })
 
-            //TODO: I can't found how to get ollama streaming input_tokens and output_tokens 
+            //TODO: I can't found how to get ollama streaming input_tokens  , part.prompt_eval_count always undefined
             let input_tokens=0
             let output_tokens=0
-            
+
             for await (const part of chatResponse) {
+
+                if (part.eval_count){
+                    output_tokens=part.eval_count
+                }
                 ctx.res.write("id: " + i + "\n");
                 ctx.res.write("event: message\n");
                 ctx.res.write("data: " + JSON.stringify({
@@ -86,6 +90,8 @@ export default class OllamaAProvider extends AbstractProvider {
                 invocation_latency: 0,
                 first_byte_latency: 0
             }
+
+            
 
             await this.saveThread(ctx, session_id, chatRequest, response);
          

--- a/src/providers/ollama_provider.ts
+++ b/src/providers/ollama_provider.ts
@@ -63,9 +63,11 @@ export default class OllamaAProvider extends AbstractProvider {
                 options
             })
 
+            //TODO: I can't found how to get ollama streaming input_tokens and output_tokens 
+            let input_tokens=0
+            let output_tokens=0
+            
             for await (const part of chatResponse) {
-                process.stdout.write(part.message.content)
-
                 ctx.res.write("id: " + i + "\n");
                 ctx.res.write("event: message\n");
                 ctx.res.write("data: " + JSON.stringify({
@@ -76,10 +78,11 @@ export default class OllamaAProvider extends AbstractProvider {
 
               }
 
+              
               const response: ResponseData = {
                 text: "",
-                input_tokens: 0,
-                output_tokens: 0,
+                input_tokens,
+                output_tokens,
                 invocation_latency: 0,
                 first_byte_latency: 0
             }
@@ -114,10 +117,11 @@ export default class OllamaAProvider extends AbstractProvider {
                 
             })
 
+            
             const response: ResponseData = {
                 text: JSON.stringify(chatResponse.message),
-                input_tokens: 0,
-                output_tokens: 0,
+                input_tokens: chatResponse.prompt_eval_count,
+                output_tokens: chatResponse.eval_count,
                 invocation_latency: 0,
                 first_byte_latency: 0
             }
@@ -127,9 +131,9 @@ export default class OllamaAProvider extends AbstractProvider {
             await this.saveThread(ctx, session_id, chatRequest, response);
             return {
                 choices:chatResponse.message, usage: {
-                    completion_tokens: 0,
-                    prompt_tokens: 0,
-                    total_tokens: 0,
+                    completion_tokens: chatResponse.eval_count,
+                    prompt_tokens: chatResponse.prompt_eval_count,
+                    total_tokens: chatResponse.eval_count+chatResponse.prompt_eval_count,
                 }
             };
         } catch (e: any) {

--- a/src/providers/ollama_provider.ts
+++ b/src/providers/ollama_provider.ts
@@ -1,0 +1,141 @@
+import { Ollama } from 'ollama'
+
+
+import { ChatRequest, ResponseData } from "../entity/chat_request"
+
+import {
+    BedrockRuntimeClient,
+    InvokeModelCommand,
+    InvokeModelWithResponseStreamCommand,
+} from "@aws-sdk/client-bedrock-runtime";
+import config from '../config';
+import helper from "../util/helper";
+import WebResponse from "../util/response";
+import AbstractProvider from "./abstract_provider";
+import ChatMessageConverter from './chat_message'
+
+
+export default class OllamaAProvider extends AbstractProvider {
+
+    client: Ollama;
+    chatMessageConverter: ChatMessageConverter;
+    constructor() {
+        super();
+        this.client = new Ollama({ host: config.ollama.host});
+        this.chatMessageConverter = new ChatMessageConverter();
+    }
+
+    async chat(chatRequest: ChatRequest, session_id: string, ctx: any) {
+
+        //we only use chatRequest.messages as ollama  input 
+        ctx.status = 200;
+
+        if (chatRequest.stream) {
+            ctx.set({
+                'Connection': 'keep-alive',
+                'Cache-Control': 'no-cache',
+                'Content-Type': 'text/event-stream',
+            });
+           await this.chatStream(ctx,"", chatRequest, session_id);
+           
+        } else {
+            ctx.set({
+                'Content-Type': 'application/json',
+            });
+            ctx.body = await this.chatSync(ctx, "", chatRequest, session_id);
+        }
+    }
+
+    async chatStream(ctx: any, input: any, chatRequest: ChatRequest, session_id: string) {
+        let i = 0;
+        try {
+            
+            const options = {
+                "temperature": chatRequest.temperature || 1.0,
+                "top_p": chatRequest.top_p || 1.0,
+            };
+
+            const messages = JSON.parse(JSON.stringify(chatRequest.messages))
+            const chatResponse=await this.client.chat({
+                model: chatRequest.model_id,
+                messages:messages,
+                stream: true,
+                options
+            })
+
+            for await (const part of chatResponse) {
+                process.stdout.write(part.message.content)
+
+                ctx.res.write("id: " + i + "\n");
+                ctx.res.write("event: message\n");
+                ctx.res.write("data: " + JSON.stringify({
+                    choices: [
+                        { delta: { content: part.message.content } }
+                    ]
+                }) + "\n\n");
+
+              }
+
+              const response: ResponseData = {
+                text: "",
+                input_tokens: 0,
+                output_tokens: 0,
+                invocation_latency: 0,
+                first_byte_latency: 0
+            }
+
+            await this.saveThread(ctx, session_id, chatRequest, response);
+         
+
+        } catch (e: any) {
+            console.error(e);
+            ctx.res.write("id: " + (i + 1) + "\n");
+            ctx.res.write("event: message\n");
+            ctx.res.write("data: " + JSON.stringify({
+                choices: [
+                    { delta: { content: "Error invoking model" } }
+                ]
+            }) + "\n\n");
+        }
+
+        ctx.res.write("id: " + (i + 1) + "\n");
+        ctx.res.write("event: message\n");
+        ctx.res.write("data: [DONE]\n\n")
+        ctx.res.end();
+    }
+
+    async chatSync(ctx: any, input: any, chatRequest: ChatRequest, session_id: string) {
+        try {
+
+            const messages = JSON.parse(JSON.stringify(chatRequest.messages))
+            const chatResponse=await this.client.chat({
+                model: chatRequest.model_id,
+                messages:messages
+                
+            })
+
+            const response: ResponseData = {
+                text: JSON.stringify(chatResponse.message),
+                input_tokens: 0,
+                output_tokens: 0,
+                invocation_latency: 0,
+                first_byte_latency: 0
+            }
+
+        
+
+            await this.saveThread(ctx, session_id, chatRequest, response);
+            return {
+                choices:chatResponse.message, usage: {
+                    completion_tokens: 0,
+                    prompt_tokens: 0,
+                    total_tokens: 0,
+                }
+            };
+        } catch (e: any) {
+            return WebResponse.error(e.message);
+        }
+
+    }
+
+}

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -7,6 +7,7 @@ import BedrockClaude from "./bedrock_claude";
 import BedrockMixtral from "./bedrock_mixtral";
 import BedrockLlama3 from "./bedrock_llama3";
 import BedrockKnowledgeBase from "./bedrock_knowledge_base";
+import OllamaAProvider from "./ollama_provider";
 
 class Provider {
     constructor() {
@@ -14,6 +15,7 @@ class Provider {
         this["bedrock-mistral"] = new BedrockMixtral();
         this["bedrock-llama3"] = new BedrockLlama3();
         this["bedrock-knowledge-base"] = new BedrockKnowledgeBase();
+        this["ollama"]=new OllamaAProvider();
     }
     async chat(ctx: any) {
         let keyData = null;

--- a/src/util/helper.ts
+++ b/src/util/helper.ts
@@ -41,6 +41,22 @@ const helper = {
     },
     refineModelParameters: async (chatRequest: ChatRequest, ctx: any) => {
         const region = chatRequest.config?.region || helper.selectRandomRegion(config.bedrock.region);
+        
+        //check ollama model prefix , etc ollama:mistral:v0.3
+        if (config.debugMode){
+            console.log("chatRequest.model", chatRequest.model,chatRequest.model.startsWith("ollama:"))
+        }
+        if (chatRequest.model.startsWith("ollama:")){
+            if (chatRequest.model.split("ollama:").length>1){
+                chatRequest.model_id =chatRequest.model.split("ollama:")[1];
+                chatRequest.provider = "ollama";
+                chatRequest.price_in = 0;
+                chatRequest.price_out = 0;
+                chatRequest.currency = "USD";
+                return chatRequest;
+            }
+        }
+
         switch (chatRequest.model) {
             case 'claude-3-sonnet':
                 chatRequest.model_id = "anthropic.claude-3-sonnet-20240229-v1:0";


### PR DESCRIPTION
I add ollama backend support , after start ollama service , you can use "ollama:" prefix , etc. ollama:mistral:v0.3, ollama:llama3 ,  default ollama host is "http://localhost:11434" 

```bash
curl http://localhost:8866/v1/chat/completions \
  -X POST \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer br-a8OTgDNsdF0vYsevxtoEeVPAyze7P" \
  -d '{
    "model": "ollama:mistral:v0.3",
    "messages": [
      {
        "role": "user",
        "content": "who are you"
      }
    ],
    "stream": true,
    "temperature": 0.1,
    "max_tokens": 4096
  }'

output:
{"choices":{"role":"assistant","content":" I am a model trained by Mistral AI. I was designed to assist with a wide range of tasks, answer questions, and engage in conversation on various topics. How can I help you today?"},"usage":{"completion_tokens":41,"prompt_tokens":7,"total_tokens":48}}

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

