### PR TITLE
修改了现有bedrock converse模式中计算maxTokens的逻辑

### DIFF
--- a/src/providers/bedrock_converse.ts
+++ b/src/providers/bedrock_converse.ts
@@ -456,13 +456,19 @@ class MessageConverter {
         if (!thinking) {
             thinking = false;
         }
-        let thinkBudget = config && config.thinkBudget;
-        if (!thinkBudget) {
-            thinkBudget = 1024;
-        }
-
-        if (maxTokens <= thinkBudget) {
-            maxTokens = thinkBudget + 1024;
+        
+        // 只有在thinking=true时才处理thinkBudget
+        let thinkBudget;
+        if (thinking) {
+            thinkBudget = config && config.thinkBudget;
+            if (!thinkBudget || thinkBudget < 1024) {
+                thinkBudget = 1024; // 确保thinkBudget最小值为1024
+            }
+            
+            // 只有在thinking=true且thinkBudget有值时才校验maxTokens
+            if (maxTokens <= thinkBudget) {
+                maxTokens = thinkBudget + 1024;
+            }
         }
 
         const messages = chatRequest.messages;


### PR DESCRIPTION
1、非思考模式下不会修改thinkBudget
2、只有在thinking=true时才进行maxTokens与thinkBudget的比较
3、thinkBudget至少为1024
4、当maxTokens不够大时，会增加到thinkBudget+1024

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
