### PR TITLE
fix x-amzn-sagemaker-custom-attributes header encoding issue for sage…

### DIFF
--- a/src/providers/sagemaker_lmi.ts
+++ b/src/providers/sagemaker_lmi.ts
@@ -66,8 +66,9 @@ export default class SagemakerLMI extends AbstractProvider {
         const CustomAttributes = ctx.headers.hasOwnProperty("x-amzn-sagemaker-custom-attributes") ?
             ctx.headers["x-amzn-sagemaker-custom-attributes"] : null;
         if (CustomAttributes && CustomAttributes.length <= 1024) {
-            input.CustomAttributes = "x-amzn-sagemaker-custom-attributes:" + encodeURIComponent(CustomAttributes);
-            // console.log(input.CustomAttributes);
+            // 检查是否已包含前缀，避免嵌套问题
+            input.CustomAttributes = CustomAttributes.startsWith("x-amzn-sagemaker-custom-attributes:") ? 
+                CustomAttributes : "x-amzn-sagemaker-custom-attributes:" + encodeURIComponent(CustomAttributes);
         }
 
         // console.log(JSON.stringify(input, null, 2));


### PR DESCRIPTION
修复了 sagemaker_lmi.ts 中的 x-amzn-sagemaker-custom-attributes 嵌套问题。

问题原因：

日志显示 x-amzn-sagemaker-custom-attributes 的值已经包含了前缀 x-amzn-sagemaker-custom-attributes:，但代码中在处理这个值时又添加了一次相同的前缀
这导致了嵌套问题，形成了类似 x-amzn-sagemaker-custom-attributes:x-amzn-sagemaker-custom-attributes:X-Path%3A%2Fv1%2Fchat%2Fcompletions 的结构
解决方案：

添加了检查逻辑，判断 CustomAttributes 是否已经以 x-amzn-sagemaker-custom-attributes: 开头
如果已经包含前缀，则直接使用原值
如果不包含前缀，则按原来的方式添加前缀