### PR TITLE
In WebResponsons.wrap, index start with 0 that will add the initial "assistant" role to response for OpenAI Compatible

### DIFF
--- a/src/providers/bedrock_converse.ts
+++ b/src/providers/bedrock_converse.ts
@@ -175,7 +175,7 @@ export default class BedrockConverse extends AbstractProvider {
             const reqId = this.newRequestID();
             // ctx.res.write("data: " + WebResponse.wrap(0, chatRequest.model, "", null, null, null, reqId) + "\n\n");
 
-            let index = 1;
+            let index = 0;
             let think_end = false;
             for await (const item of response.stream) {
                 console.log(JSON.stringify(item));


### PR DESCRIPTION
In WebResponsons.wrap, index start with 0 that will add the initial "assistant" role to response for OpenAI Compatible

*Issue #, if available:*

*Description of changes:* In WebResponsons.wrap, index start with 0 that will add the initial "assistant" role to response for OpenAI Compatible. the index change to start with 1 in 0c99aa5eedad1a8bebbb3deaa5f1dcb9d02a0826 Commits on Sep 20, 2024.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
