### PR TITLE
Pass tool calls to model for openai_compatible provider

### DIFF
--- a/src/providers/openai_compatible.ts
+++ b/src/providers/openai_compatible.ts
@@ -65,7 +65,9 @@ export default class OpenAICompatible extends AbstractProvider {
       temperature: chatRequest.temperature || 1.0,
       top_p: chatRequest.top_p || 1.0,
       max_tokens: chatRequest.max_tokens,
-      stream: true
+      stream: true,
+      ...(chatRequest.tools && { tools: chatRequest.tools }),
+      ...(chatRequest.tool_choice && { tool_choice: chatRequest.tool_choice })
     });
 
 
@@ -109,7 +111,9 @@ export default class OpenAICompatible extends AbstractProvider {
       temperature: chatRequest.temperature || 1.0,
       top_p: chatRequest.top_p || 1.0,
       max_tokens: chatRequest.max_tokens,
-      messages: messages
+      messages: messages,
+      ...(chatRequest.tools && { tools: chatRequest.tools }),
+      ...(chatRequest.tool_choice && { tool_choice: chatRequest.tool_choice })
     });
 
     const {


### PR DESCRIPTION
*Description of changes:*

Allows passing of chatRequest tools when using openai_compatible provider, allowing tool calls from OpenAI protocol clients to bedrock models.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
