### PR TITLE
Fix: Include tool_calls in response when Claude uses tools without text

### DIFF
--- a/src/providers/bedrock_converse.ts
+++ b/src/providers/bedrock_converse.ts
@@ -419,6 +419,7 @@ export default class BedrockConverse extends AbstractProvider {
         let assistantMessage: any = { role: "assistant" };
         let hasReasoningContent = false;
         let hasContent = false;
+        let hasToolCalls = false;
 
         // console.log(1111, content);
 
@@ -442,7 +443,8 @@ export default class BedrockConverse extends AbstractProvider {
                             arguments: JSON.stringify(c.toolUse.input)
                         }
                     }
-                ]
+                ];
+                hasToolCalls = true;
             }
             // if (c.toolUse) {
             //     choices.push({
@@ -464,7 +466,7 @@ export default class BedrockConverse extends AbstractProvider {
             // }
         });
 
-        if (hasReasoningContent || hasContent) {
+        if (hasReasoningContent || hasContent || hasToolCalls) {
             choices.unshift({
                 index: 0,
                 message: assistantMessage


### PR DESCRIPTION
## Summary
Fixed an issue where assistant messages with `tool_calls` were excluded from the
response when Claude uses tools without generating text content.

## Changes
- Added `hasToolCalls` flag to track when tools are used
- Updated condition to include messages with tool_calls regardless of text content

## Test plan
- [x] Backend compiles successfully with `npm run build-server`
- [x] Test with Claude API calls using tools without text content