### PR TITLE
Fix: Correct debug mode message display

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ app.listen(port, () => {
         console.log(`Performance mode is ${config.performanceMode}.`);
     }
     if (config.debugMode) {
-        console.log(`Debug mode is ${config.performanceMode}.`);
+        console.log(`Debug mode is ${config.debugMode}.`);
     }
     if (config.pgsql.debugMode) {
         console.log(`Sql mode is on.`);


### PR DESCRIPTION
   Fixed console log to show debugMode value instead of performanceMode value.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
