### PR TITLE
feat: add Anthropic Messages API compatible endpoint (POST /v1/messages)

### DIFF
--- a/src/controller/runtime/anthropic.ts
+++ b/src/controller/runtime/anthropic.ts
@@ -1,0 +1,11 @@
+import provider from '../../providers/provider';
+
+/**
+ * Anthropic Messages API controller
+ * POST /v1/messages
+ */
+export default {
+    messages: async (ctx: any) => {
+        return provider.anthropicMessages(ctx);
+    }
+}

--- a/src/providers/bedrock_converse.ts
+++ b/src/providers/bedrock_converse.ts
@@ -8,6 +8,7 @@ import helper from "../util/helper";
 // import config from "../config";
 import WebResponse from "../util/response";
 import AbstractProvider from "./abstract_provider";
+import AnthropicResponse from '../util/anthropic_response';
 
 /**
 * BedrockConverse Provider uses boto3-converse api to invoke LLM models and support function calling.
@@ -488,6 +489,204 @@ export default class BedrockConverse extends AbstractProvider {
                 total_tokens: totalTokens
             }
         };
+    }
+
+    /**
+     * Anthropic Messages API compatible chat
+     * Reuses the same Bedrock Converse payload builder, but responds in Anthropic schema.
+     */
+    async chatAnthropic(chatRequest: ChatRequest, session_id: string, ctx: any) {
+        await this.init();
+
+        const payload = await this.chatMessageConverter.toPayload(chatRequest, this.modelData.config);
+        payload['modelId'] = chatRequest.model_id || this.modelId;
+
+        ctx.status = 200;
+
+        if (chatRequest.stream) {
+            ctx.set({
+                'Content-Type': 'text/event-stream',
+                'Cache-Control': 'no-cache',
+                'Connection': 'keep-alive',
+            });
+            await this.chatAnthropicStream(ctx, payload, chatRequest, session_id);
+        } else {
+            ctx.set({ 'Content-Type': 'application/json' });
+            ctx.body = await this.chatAnthropicSync(ctx, payload, chatRequest, session_id);
+        }
+    }
+
+    async chatAnthropicStream(ctx: any, input: any, chatRequest: ChatRequest, session_id: string) {
+        
+        const command = new ConverseStreamCommand(input);
+        const response = await this.client.send(command);
+
+        if (!response.stream) throw new Error('No response stream.');
+
+        const msgId = AnthropicResponse.messageId();
+        let responseText = '';
+        let inputTokens = 0;
+        let outputTokens = 0;
+        let stopReason = 'end_turn';
+        let blockIndex = 0;
+        // contentBlockIndex (Bedrock) -> { toolIndex, toolId, toolName, argsBuffer }
+        const toolBlockMap: Map<number, { index: number, id: string, name: string, args: string }> = new Map();
+        let nextToolIndex = 0;
+        let textBlockOpen = false;
+        let thinkBlockOpen = false;
+
+        ctx.res.write(AnthropicResponse.ping());
+        // message_start with placeholder input tokens (updated at end)
+        ctx.res.write(AnthropicResponse.messageStart(msgId, chatRequest.model, 0));
+
+        for await (const item of response.stream) {
+            // Tool use block start
+            if (item.contentBlockStart?.start?.toolUse) {
+                const cbIdx = item.contentBlockStart.contentBlockIndex;
+                const tu = item.contentBlockStart.start.toolUse;
+                const toolIdx = nextToolIndex++;
+                toolBlockMap.set(cbIdx, { index: blockIndex, id: tu.toolUseId, name: tu.name, args: '' });
+                ctx.res.write(AnthropicResponse.contentBlockStart(blockIndex, {
+                    type: 'tool_use',
+                    id: tu.toolUseId,
+                    name: tu.name,
+                    input: {}
+                }));
+                blockIndex++;
+            }
+
+            if (item.contentBlockDelta) {
+                const cbIdx = item.contentBlockDelta.contentBlockIndex;
+                const delta = item.contentBlockDelta.delta;
+
+                // Thinking / reasoning
+                if (delta?.reasoningContent?.text) {
+                    if (!thinkBlockOpen) {
+                        ctx.res.write(AnthropicResponse.contentBlockStart(blockIndex, { type: 'thinking', thinking: '' }));
+                        thinkBlockOpen = true;
+                    }
+                    ctx.res.write(AnthropicResponse.contentBlockDelta(blockIndex, {
+                        type: 'thinking_delta',
+                        thinking: delta.reasoningContent.text
+                    }));
+                }
+
+                // Text
+                if (delta?.text) {
+                    if (thinkBlockOpen) {
+                        ctx.res.write(AnthropicResponse.contentBlockStop(blockIndex));
+                        thinkBlockOpen = false;
+                        blockIndex++;
+                    }
+                    if (!textBlockOpen) {
+                        ctx.res.write(AnthropicResponse.contentBlockStart(blockIndex, { type: 'text', text: '' }));
+                        textBlockOpen = true;
+                    }
+                    responseText += delta.text;
+                    ctx.res.write(AnthropicResponse.contentBlockDelta(blockIndex, {
+                        type: 'text_delta',
+                        text: delta.text
+                    }));
+                }
+
+                // Tool input args
+                if (delta?.toolUse?.input !== undefined) {
+                    const tb = toolBlockMap.get(cbIdx);
+                    if (tb) {
+                        tb.args += delta.toolUse.input;
+                        ctx.res.write(AnthropicResponse.contentBlockDelta(tb.index, {
+                            type: 'input_json_delta',
+                            partial_json: delta.toolUse.input
+                        }));
+                    }
+                }
+            }
+
+            if (item.contentBlockStop) {
+                const cbIdx = item.contentBlockStop.contentBlockIndex;
+                if (toolBlockMap.has(cbIdx)) {
+                    const tb = toolBlockMap.get(cbIdx)!;
+                    ctx.res.write(AnthropicResponse.contentBlockStop(tb.index));
+                } else if (textBlockOpen) {
+                    ctx.res.write(AnthropicResponse.contentBlockStop(blockIndex));
+                    textBlockOpen = false;
+                    blockIndex++;
+                } else if (thinkBlockOpen) {
+                    ctx.res.write(AnthropicResponse.contentBlockStop(blockIndex));
+                    thinkBlockOpen = false;
+                    blockIndex++;
+                }
+            }
+
+            if (item.messageStop?.stopReason) {
+                stopReason = AnthropicResponse.mapStopReason(item.messageStop.stopReason);
+            }
+
+            if (item.metadata) {
+                inputTokens = item.metadata.usage.inputTokens;
+                outputTokens = item.metadata.usage.outputTokens;
+            }
+        }
+
+        ctx.res.write(AnthropicResponse.messageDelta(stopReason, outputTokens));
+        ctx.res.write(AnthropicResponse.messageStop());
+        ctx.res.end();
+
+        await this.saveThread(ctx, session_id, chatRequest, {
+            text: responseText,
+            input_tokens: inputTokens,
+            output_tokens: outputTokens,
+            invocation_latency: 0,
+            first_byte_latency: 0
+        });
+    }
+
+    async chatAnthropicSync(ctx: any, input: any, chatRequest: ChatRequest, session_id: string) {
+        
+        const command = new ConverseCommand(input);
+        const apiResponse = await this.client.send(command);
+
+        const rawContent = apiResponse.output.message?.content || [];
+        const { inputTokens, outputTokens } = apiResponse.usage;
+        const { latencyMs } = apiResponse.metrics;
+        const stopReason = AnthropicResponse.mapStopReason(apiResponse.stopReason || 'end_turn');
+
+        // Build Anthropic content array
+        const content: any[] = [];
+        let responseText = '';
+
+        for (const c of rawContent) {
+            if (c.reasoningContent) {
+                content.push({ type: 'thinking', thinking: c.reasoningContent.reasoningText?.text || '' });
+            }
+            if (c.text) {
+                responseText = c.text;
+                content.push({ type: 'text', text: c.text });
+            }
+            if (c.toolUse) {
+                content.push({
+                    type: 'tool_use',
+                    id: c.toolUse.toolUseId,
+                    name: c.toolUse.name,
+                    input: c.toolUse.input
+                });
+            }
+        }
+
+        await this.saveThread(ctx, session_id, chatRequest, {
+            text: responseText,
+            input_tokens: inputTokens,
+            output_tokens: outputTokens,
+            invocation_latency: 0,
+            first_byte_latency: latencyMs
+        });
+
+        return AnthropicResponse.wrapSync(
+            chatRequest.model,
+            content,
+            stopReason,
+            { input_tokens: inputTokens, output_tokens: outputTokens }
+        );
     }
 }
 

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -192,6 +192,165 @@ class Provider {
         return res.provider.chat(res.chatRequest, res.session_id, ctx);
     }
 
+    async anthropicMessages(ctx: any) {
+        const res = await this.initForAnthropic(ctx);
+        return (res.provider as any).chatAnthropic(res.chatRequest, res.session_id, ctx);
+    }
+
+    async initForAnthropic(ctx: any) {
+        if (ctx.user && ctx.user.id > 0) {
+            await this.checkFee(ctx, ctx.user);
+        }
+
+        // Convert Anthropic Messages API request → internal ChatRequest
+        const body = ctx.request.body;
+        const chatRequest: ChatRequest = this.convertAnthropicRequest(body);
+
+        const modelRes = helper.parseModelString(chatRequest.model);
+        if (modelRes) {
+            chatRequest.model = modelRes.model;
+            chatRequest.model_id = modelRes.model_id;
+        }
+
+        const session_id = ctx.headers["session-id"];
+        const modelData = await helper.refineModelParameters(chatRequest, ctx);
+
+        if (ctx.db) {
+            const canAccessModel = await this.checkModelAccess(ctx, ctx.user, modelData.id);
+            if (!canAccessModel) {
+                throw new Error(`You do not have permission to access the [${modelData.name}] model, please contact the administrator.`);
+            }
+        }
+
+        chatRequest.currency = modelData.config.currency || "USD";
+        chatRequest.price_in = modelData.price_in || 0;
+        chatRequest.price_out = modelData.price_out || 0;
+        chatRequest.model = modelData.name;
+
+        const provider: AbstractProvider = this[modelData.provider];
+        if (!provider) {
+            throw new Error("You need to configure the provider correctly.");
+        }
+        provider.setModelData(modelData);
+        provider.setKeyData(ctx.user);
+
+        return { provider, chatRequest, session_id };
+    }
+
+    /**
+     * Convert Anthropic Messages API request body → internal ChatRequest format
+     * Anthropic spec: https://docs.anthropic.com/en/api/messages
+     */
+    convertAnthropicRequest(body: any): ChatRequest {
+        const messages: any[] = [];
+
+        // system prompt → system message
+        if (body.system) {
+            const systemContent = typeof body.system === 'string'
+                ? body.system
+                : body.system.map((b: any) => b.text || '').join('');
+            messages.push({ role: 'system', content: systemContent });
+        }
+
+        // Convert Anthropic messages → OpenAI-style messages
+        for (const msg of (body.messages || [])) {
+            if (msg.role === 'user' || msg.role === 'assistant') {
+                const converted: any = { role: msg.role };
+
+                if (typeof msg.content === 'string') {
+                    converted.content = msg.content;
+                } else if (Array.isArray(msg.content)) {
+                    // Check for tool_use / tool_result blocks
+                    const toolUseBlocks = msg.content.filter((b: any) => b.type === 'tool_use');
+                    const toolResultBlocks = msg.content.filter((b: any) => b.type === 'tool_result');
+                    const textBlocks = msg.content.filter((b: any) => b.type === 'text' || b.type === 'image');
+
+                    if (toolResultBlocks.length > 0) {
+                        // tool result messages: emit one tool message per result
+                        for (const tr of toolResultBlocks) {
+                            const resultContent = Array.isArray(tr.content)
+                                ? tr.content.map((c: any) => c.text || '').join('')
+                                : (tr.content || '');
+                            messages.push({
+                                role: 'tool',
+                                tool_call_id: tr.tool_use_id,
+                                content: resultContent
+                            });
+                        }
+                        continue;
+                    }
+
+                    if (toolUseBlocks.length > 0) {
+                        // assistant tool_use → tool_calls
+                        converted.content = textBlocks
+                            .filter((b: any) => b.type === 'text')
+                            .map((b: any) => b.text)
+                            .join('') || null;
+                        converted.tool_calls = toolUseBlocks.map((b: any) => ({
+                            id: b.id,
+                            type: 'function',
+                            function: {
+                                name: b.name,
+                                arguments: typeof b.input === 'string' ? b.input : JSON.stringify(b.input)
+                            }
+                        }));
+                    } else {
+                        // regular content array → OpenAI content array
+                        converted.content = msg.content.map((b: any) => {
+                            if (b.type === 'text') return { type: 'text', text: b.text };
+                            if (b.type === 'image') {
+                                if (b.source?.type === 'base64') {
+                                    return {
+                                        type: 'image_url',
+                                        image_url: { url: `data:${b.source.media_type};base64,${b.source.data}` }
+                                    };
+                                } else if (b.source?.type === 'url') {
+                                    return { type: 'image_url', image_url: { url: b.source.url } };
+                                }
+                            }
+                            return b;
+                        });
+                    }
+                }
+                messages.push(converted);
+            }
+        }
+
+        // Convert Anthropic tools → OpenAI tools
+        const tools = body.tools?.map((t: any) => ({
+            type: 'function',
+            function: {
+                name: t.name,
+                description: t.description || '',
+                parameters: t.input_schema
+            }
+        }));
+
+        // Convert tool_choice
+        let tool_choice: any;
+        if (body.tool_choice) {
+            if (body.tool_choice.type === 'auto') tool_choice = 'auto';
+            else if (body.tool_choice.type === 'any') tool_choice = 'required';
+            else if (body.tool_choice.type === 'tool') {
+                tool_choice = { type: 'function', function: { name: body.tool_choice.name } };
+            }
+        }
+
+        const req: ChatRequest = {
+            model: body.model,
+            messages,
+            stream: body.stream || false,
+            max_tokens: body.max_tokens,
+            temperature: body.temperature,
+            top_p: body.top_p,
+        };
+        if (tools?.length) req.tools = tools;
+        if (tool_choice !== undefined) req.tool_choice = tool_choice;
+        if (body.stop_sequences?.length) req.stop = body.stop_sequences;
+
+        return req;
+    }
+
     async complete(ctx: any) {
         // let keyData = null;
         const res = await this.init(ctx);

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,6 +1,7 @@
 import Router from "koa-router";
 // import chat from './controller/runtime/chat';
 import v1 from './controller/runtime/v1';
+import anthropic from './controller/runtime/anthropic';
 import models from './controller/runtime/models';
 import config from './config';
 import admin_statistics_controller from './controller/admin/StatisticsController';
@@ -32,6 +33,9 @@ router.post("/v1/completions", v1.completions);
 router.post("/v1/embeddings", v1.embeddings);
 router.post("/v1/images/generations", v1.images);
 router.get("/v1/models", models.list);
+
+// Anthropic Messages API
+router.post("/v1/messages", anthropic.messages);
 
 // Admin APIs
 admin_statistics_controller(router);

--- a/src/util/anthropic_response.ts
+++ b/src/util/anthropic_response.ts
@@ -1,0 +1,100 @@
+import crypto from 'crypto';
+
+/**
+ * Anthropic Messages API response helpers
+ * Spec: https://docs.anthropic.com/en/api/messages
+ */
+
+export default {
+    messageId() {
+        return 'msg_' + crypto.randomUUID().replace(/-/g, '').substring(0, 24);
+    },
+
+    // Non-streaming response
+    wrapSync(model: string, content: any[], stopReason: string, usage: { input_tokens: number, output_tokens: number }, requestId?: string) {
+        return {
+            id: this.messageId(),
+            type: 'message',
+            role: 'assistant',
+            model,
+            content,
+            stop_reason: stopReason,
+            stop_sequence: null,
+            usage: {
+                input_tokens: usage.input_tokens,
+                output_tokens: usage.output_tokens,
+            }
+        };
+    },
+
+    // SSE event helpers
+    sseEvent(event: string, data: any) {
+        return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+    },
+
+    messageStart(msgId: string, model: string, inputTokens: number) {
+        return this.sseEvent('message_start', {
+            type: 'message_start',
+            message: {
+                id: msgId,
+                type: 'message',
+                role: 'assistant',
+                model,
+                content: [],
+                stop_reason: null,
+                stop_sequence: null,
+                usage: { input_tokens: inputTokens, output_tokens: 0 }
+            }
+        });
+    },
+
+    contentBlockStart(index: number, block: any) {
+        return this.sseEvent('content_block_start', {
+            type: 'content_block_start',
+            index,
+            content_block: block
+        });
+    },
+
+    contentBlockDelta(index: number, delta: any) {
+        return this.sseEvent('content_block_delta', {
+            type: 'content_block_delta',
+            index,
+            delta
+        });
+    },
+
+    contentBlockStop(index: number) {
+        return this.sseEvent('content_block_stop', {
+            type: 'content_block_stop',
+            index
+        });
+    },
+
+    messageDelta(stopReason: string, outputTokens: number) {
+        return this.sseEvent('message_delta', {
+            type: 'message_delta',
+            delta: { stop_reason: stopReason, stop_sequence: null },
+            usage: { output_tokens: outputTokens }
+        });
+    },
+
+    messageStop() {
+        return this.sseEvent('message_stop', { type: 'message_stop' });
+    },
+
+    ping() {
+        return this.sseEvent('ping', { type: 'ping' });
+    },
+
+    // Map Bedrock stop reason → Anthropic stop reason
+    mapStopReason(bedrockReason: string): string {
+        switch (bedrockReason) {
+            case 'end_turn': return 'end_turn';
+            case 'tool_use': return 'tool_use';
+            case 'max_tokens': return 'max_tokens';
+            case 'stop_sequence': return 'stop_sequence';
+            default: return 'end_turn';
+        }
+    }
+};


### PR DESCRIPTION
## Summary
Adds a new endpoint `POST /v1/messages` that is compatible with the Anthropic Messages API, allowing clients that use the Anthropic SDK to connect directly to this connector without modification.
## Changes
### New files
- `src/controller/runtime/anthropic.ts` — route handler for `/v1/messages`
- `src/util/anthropic_response.ts` — Anthropic SSE event and response serialization helpers
### Modified files
- `src/providers/bedrock_converse.ts` — added `chatAnthropic()`, `chatAnthropicStream()`, `chatAnthropicSync()` methods
- `src/providers/provider.ts` — added `anthropicMessages()` and `initForAnthropic()` with request conversion logic
- `src/routes.ts` — registered `POST /v1/messages`
## Also included
- Bug fix: remove `temperature`/`topP` for `claude-opus-4` and later models (deprecated by Anthropic)
- Build fix: remove hardcoded local path alias for `kui-vue` in `vite.config.js`