### PR TITLE
docs: update changelogs and README for v0.0.41

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,22 +44,31 @@ Once defined, models can be bound to groups or API Keys.
 
 ## Changelogs
 
+## 0.0.41
+
+1. **Anthropic Messages API Compatibility** - Added a new endpoint `POST /v1/messages` that is fully compatible with the Anthropic Messages API. Clients using the Anthropic SDK can now connect directly without modification. Supports text, tool use, thinking content blocks, and both streaming and non-streaming modes.
+
+2. **x-api-key Header Support** - Added support for the `x-api-key` header (Anthropic SDK default) in addition to the existing `Authorization: Bearer` header.
+
+3. **Bug Fix: claude-opus-4 temperature/topP** - Removed deprecated `temperature` and `topP` parameters for `claude-opus-4` and later models.
+
+4. **Build Fix** - Removed hardcoded local path alias for `kui-vue` in `vite.config.js`. Downgraded `vite` from experimental `rolldown-vite` to stable `^6.3.3`.
+
+## 0.0.40
+
+1. **AWS Bedrock Bearer Token Support** - Added support for AWS Bedrock API Key (Bearer Token) authentication in addition to traditional AKSK credentials.
+
+2. **Multi-tool Call Fix** - Fixed an issue where multiple tool calls in a single response were not handled correctly in streaming mode.
+
 ## 0.0.38
 
-1. **Bedrock App Profiles Support** - Added support for Bedrock application profiles, allowing better configuration management for different deployment scenarios. [#87](https://github.com/aws-samples/sample-connector-for-bedrock/issues/87)
+1. **Bedrock App Profiles Support** - Added support for Bedrock application profiles. [#87](https://github.com/aws-samples/sample-connector-for-bedrock/issues/87)
 
-2. **PostgreSQL Database Upgrade** - Upgraded standalone PostgreSQL database from version 16.3 to 16.10 for improved performance and security. [#89](https://github.com/aws-samples/sample-connector-for-bedrock/pull/89)
+2. **PostgreSQL Database Upgrade** - Upgraded standalone PostgreSQL database from version 16.3 to 16.10. [#89](https://github.com/aws-samples/sample-connector-for-bedrock/pull/89)
 
 3. **Zero-Length Messages Fix** - Fixed an issue where Bedrock would fail when processing zero-length messages. [#90](https://github.com/aws-samples/sample-connector-for-bedrock/pull/90)
 
 4. **Tool Use Enhancement** - Improved tool use functionality with bug fixes and stability improvements. [#91](https://github.com/aws-samples/sample-connector-for-bedrock/pull/91) [#92](https://github.com/aws-samples/sample-connector-for-bedrock/pull/92)
-
-
-## 0.0.37
-
-1. **bedrock-converse Provider Fix** - Fixed an issue with Claude new models: 'The model returned the following errors: temperature and top_p cannot both be specified for this model. Please use only one.'
-
-2. **Frontend Caching Enhancement** - Added 1-month caching for frontend pages served by koa-static-server.
 
 [More changelogs](https://aws-samples.github.io/sample-connector-for-bedrock/home/changelogs/)
 

--- a/docs/home/changelogs.md
+++ b/docs/home/changelogs.md
@@ -1,5 +1,21 @@
 # Changelogs
 
+## 0.0.41
+
+1. **Anthropic Messages API Compatibility** - Added a new endpoint `POST /v1/messages` that is fully compatible with the Anthropic Messages API. Clients using the Anthropic SDK can now connect directly without modification. Supports text, tool use, thinking content blocks, and both streaming and non-streaming modes.
+
+2. **x-api-key Header Support** - Added support for the `x-api-key` header (Anthropic SDK default) in addition to the existing `Authorization: Bearer` header.
+
+3. **Bug Fix: claude-opus-4 temperature/topP** - Removed deprecated `temperature` and `topP` parameters for `claude-opus-4` and later models, which caused `invalid_request_error`.
+
+4. **Build Fix** - Removed hardcoded local path alias for `kui-vue` in `vite.config.js` that caused build failures on non-author machines. Downgraded `vite` from experimental `rolldown-vite` to stable `^6.3.3`.
+
+## 0.0.40
+
+1. **AWS Bedrock Bearer Token Support** - Added support for AWS Bedrock API Key (Bearer Token) authentication method in addition to traditional AKSK credentials.
+
+2. **Multi-tool Call Fix** - Fixed an issue where multiple tool calls in a single response were not handled correctly in streaming mode.
+
 ## 0.0.38
 
 1. **Bedrock App Profiles Support** - Added support for Bedrock application profiles, allowing better configuration management for different deployment scenarios. [#87](https://github.com/aws-samples/sample-connector-for-bedrock/issues/87)

--- a/docs/home/changelogs.zh.md
+++ b/docs/home/changelogs.zh.md
@@ -1,5 +1,21 @@
 # 更新日志
 
+## 0.0.41
+
+1. **Anthropic Messages API 兼容** - 新增 `POST /v1/messages` 端点，完全兼容 Anthropic Messages API。使用 Anthropic SDK 的客户端无需任何修改即可直接接入。支持 text、tool use、thinking 内容块，以及流式和非流式两种模式。
+
+2. **支持 x-api-key 认证头** - 新增对 `x-api-key` header（Anthropic SDK 默认认证方式）的支持，同时保留原有的 `Authorization: Bearer` 方式。
+
+3. **Bug 修复：claude-opus-4 temperature/topP** - 修复了向 `claude-opus-4` 及更新模型发送已废弃的 `temperature` 和 `topP` 参数导致 `invalid_request_error` 的问题。
+
+4. **构建修复** - 移除了 `vite.config.js` 中硬编码的本地 `kui-vue` 路径别名（导致非作者机器构建失败），将 `vite` 从实验性的 `rolldown-vite` 降级为稳定版 `^6.3.3`。
+
+## 0.0.40
+
+1. **AWS Bedrock Bearer Token 支持** - 新增对 AWS Bedrock API Key（Bearer Token）认证方式的支持，可与传统 AKSK 凭证方式并用。
+
+2. **多工具调用修复** - 修复了流式模式下单次响应包含多个工具调用时处理不正确的问题。
+
 ## 0.0.38
 
 1. **Bedrock 应用配置文件支持** - 添加了对 Bedrock 应用配置文件的支持，允许为不同的部署场景提供更好的配置管理。[#87](https://github.com/aws-samples/sample-connector-for-bedrock/issues/87)


### PR DESCRIPTION
Update changelogs and README to document the new features and fixes in v0.0.41:
- Anthropic Messages API compatibility (`POST /v1/messages`)
- x-api-key header support
- Bug fix: claude-opus-4 temperature/topP
- Build fix: vite config cleanup
Both English and Chinese changelogs updated.