### PR TITLE
feat: support thinking param from Anthropic request body

### DIFF
--- a/src/providers/bedrock_converse.ts
+++ b/src/providers/bedrock_converse.ts
@@ -815,20 +815,28 @@ class MessageConverter {
         if (config.maxTokens && (maxTokens > config.maxTokens)) {
             maxTokens = config.maxTokens;
         }
-        let thinking = config && config.thinking;
-        if (!thinking) {
+        // Resolve thinking: request body takes precedence over model config.
+        // Anthropic SDK sends: { thinking: { type: "enabled", budget_tokens: N } }
+        let thinking = false;
+        let thinkBudget: number | undefined;
+
+        if (chatRequest.thinking?.type === 'enabled') {
+            // Client explicitly enabled thinking
+            thinking = true;
+            thinkBudget = chatRequest.thinking.budget_tokens;
+        } else if (chatRequest.thinking?.type === 'disabled') {
+            // Client explicitly disabled thinking — honour it even if config says true
             thinking = false;
+        } else if (config && config.thinking) {
+            // Fall back to model config (backward compat)
+            thinking = true;
+            thinkBudget = config.thinkBudget;
         }
 
-        // 只有在thinking=true时才处理thinkBudget
-        let thinkBudget;
         if (thinking) {
-            thinkBudget = config && config.thinkBudget;
             if (!thinkBudget || thinkBudget < 1024) {
-                thinkBudget = 1024; // 确保thinkBudget最小值为1024
+                thinkBudget = 1024; // minimum budget_tokens
             }
-
-            // 只有在thinking=true且thinkBudget有值时才校验maxTokens
             if (maxTokens <= thinkBudget) {
                 maxTokens = thinkBudget + 1024;
             }

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -348,6 +348,9 @@ class Provider {
         if (tool_choice !== undefined) req.tool_choice = tool_choice;
         if (body.stop_sequences?.length) req.stop = body.stop_sequences;
 
+        // Carry thinking param from Anthropic request body
+        if (body.thinking !== undefined) req.thinking = body.thinking;
+
         return req;
     }
 


### PR DESCRIPTION
## Summary

- Reads `thinking: { type: "enabled", budget_tokens: N }` directly from the Anthropic SDK request body
- Establishes a clear priority chain: **request body → disabled override → model config fallback**
- Previously, extended thinking could only be activated via model config (`config.thinking`) or the custom `think-budget` header — standard Anthropic SDK clients were silently ignored

## Changes

- `src/providers/provider.ts` — carry `thinking` field through `convertAnthropicRequest()`
- `src/providers/bedrock_converse.ts` — replace thinking resolution block with priority-based logic

## Test plan

- [ ] Anthropic SDK client sending `thinking: { type: "enabled", budget_tokens: 8000 }` activates extended thinking
- [ ] `thinking: { type: "disabled" }` suppresses thinking even when model config has `thinking: true`
- [ ] Existing `config.thinking` / `think-budget` header behaviour unchanged (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)