### PR TITLE
feat: support anthropic-beta header passthrough with Bedrock blocklist filtering

### DIFF
--- a/src/providers/bedrock_converse.ts
+++ b/src/providers/bedrock_converse.ts
@@ -2,6 +2,24 @@ import { ChatRequest, ResponseData } from "../entity/chat_request"
 import {
     BedrockRuntimeClient, ConverseStreamCommand, ConverseCommand
 } from "@aws-sdk/client-bedrock-runtime";
+
+/**
+ * Anthropic beta headers that Bedrock does NOT support and must be stripped
+ * before forwarding requests.  Claude Code (and other Anthropic SDK clients)
+ * send these automatically; passing them to Bedrock causes validation errors.
+ */
+const BEDROCK_BETA_BLOCKLIST: ReadonlySet<string> = new Set([
+    // Files API – Bedrock has no equivalent
+    "files-api-2025-04-14",
+    // Computer-use – not supported on Bedrock Converse
+    "computer-use-2025-01-24",
+    // Prompt-caching scope flag – Bedrock handles caching differently
+    "prompt-caching-scope-2026-01-05",
+    // Redact-thinking – Anthropic-internal, not a Bedrock feature
+    "redact-thinking-2026-02-12",
+    // Advisor tool – Anthropic-internal
+    "advisor-tool-2026-03-01",
+]);
 import { NodeHttpHandler } from "@smithy/node-http-handler";
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import helper from "../util/helper";
@@ -87,7 +105,8 @@ export default class BedrockConverse extends AbstractProvider {
 
     async complete(chatRequest: ChatRequest, session_id: string, ctx: any) {
         await this.init();
-        const payload = await this.chatMessageConverter.toPayload(chatRequest, this.modelData.config);
+        const clientBetaHeader = ctx.headers?.["anthropic-beta"] as string | undefined;
+        const payload = await this.chatMessageConverter.toPayload(chatRequest, this.modelData.config, clientBetaHeader);
         if (chatRequest.model_id) {
             payload["modelId"] = chatRequest.model_id;
         } else {
@@ -127,7 +146,8 @@ export default class BedrockConverse extends AbstractProvider {
             // console.log(this.modelData.config)
         }
 
-        const payload = await this.chatMessageConverter.toPayload(chatRequest, this.modelData.config);
+        const clientBetaHeader = ctx.headers?.["anthropic-beta"] as string | undefined;
+        const payload = await this.chatMessageConverter.toPayload(chatRequest, this.modelData.config, clientBetaHeader);
         if (chatRequest.model_id) {
             payload["modelId"] = chatRequest.model_id;
         } else {
@@ -804,7 +824,7 @@ class MessageConverter {
     }
 
 
-    async toPayload(chatRequest: ChatRequest, config: any): Promise<any> {
+    async toPayload(chatRequest: ChatRequest, config: any, clientBetaHeader?: string): Promise<any> {
 
         let maxTokens = config && config.maxTokens;
         if (!maxTokens || isNaN(maxTokens)) {
@@ -893,18 +913,31 @@ class MessageConverter {
                     delete inferenceConfig.topP;
                 }
             }
-            const anthropicBetaFeatures = [];
+            // Auto-inject model-specific beta features required by Bedrock.
+            const anthropicBetaFeatures = new Set<string>();
             if (config.modelId.includes("anthropic.claude-3-7-sonnet")) {
-                anthropicBetaFeatures.push("output-128k-2025-02-19")
-                anthropicBetaFeatures.push("token-efficient-tools-2025-02-19")
+                anthropicBetaFeatures.add("output-128k-2025-02-19");
+                anthropicBetaFeatures.add("token-efficient-tools-2025-02-19");
             }
             if (config.modelId.includes("anthropic.claude-sonnet-4")) {
-                anthropicBetaFeatures.push("context-1m-2025-08-07")
+                anthropicBetaFeatures.add("context-1m-2025-08-07");
             }
             if (config.modelId.includes("anthropic.claude-sonnet-4-5")) {
-                anthropicBetaFeatures.push("context-management-2025-06-27")
+                anthropicBetaFeatures.add("context-management-2025-06-27");
             }
-            additionalModelRequestFields["anthropic_beta"] = anthropicBetaFeatures;
+
+            // Merge client-supplied anthropic-beta header values, filtering out
+            // anything in BEDROCK_BETA_BLOCKLIST (Bedrock-unsupported headers).
+            if (clientBetaHeader) {
+                for (const value of clientBetaHeader.split(",")) {
+                    const trimmed = value.trim();
+                    if (trimmed && !BEDROCK_BETA_BLOCKLIST.has(trimmed)) {
+                        anthropicBetaFeatures.add(trimmed);
+                    }
+                }
+            }
+
+            additionalModelRequestFields["anthropic_beta"] = Array.from(anthropicBetaFeatures);
         }
         //First element must be user message
         const newMessages = [];

--- a/src/providers/bedrock_converse.ts
+++ b/src/providers/bedrock_converse.ts
@@ -1019,7 +1019,21 @@ class MessageConverter {
 
             // 处理普通 user 消息
             if (message.role === 'user') {
-                message.content = await this.convertContent(message.content);
+                if (Array.isArray(message.content)) {
+                    // Preserve cache_control: convert each block individually,
+                    // injecting a cachePoint after any block that carries cache_control.
+                    const converted: any[] = [];
+                    for (const item of message.content) {
+                        const block = await this.convertConverseSingleType(item);
+                        if (block) converted.push(block);
+                        if (item.cache_control?.type === 'ephemeral') {
+                            converted.push({ cachePoint: { type: 'default' } });
+                        }
+                    }
+                    message.content = converted.length > 0 ? converted : [{ text: '.' }];
+                } else {
+                    message.content = await this.convertContent(message.content);
+                }
                 newMessages.push(message);
                 continue;
             }
@@ -1084,24 +1098,33 @@ class MessageConverter {
 
         const rtn: any = { messages: alternatingMessages, inferenceConfig, additionalModelRequestFields };
 
-        if (systemMessages.length > 0) {
+        if (systemMessages.length > 0 || chatRequest.system_blocks?.length > 0) {
             const system = [];
-            systemMessages.forEach(msg => {
-                if (msg.content && (typeof msg.content === "string")) {
-                    system.push({ text: msg.content });
-                } else if (msg.content && Array.isArray(msg.content)) {
-                    msg.content.forEach((msg2: any) => {
-                        msg2?.text && system.push({ text: msg2.text });
-                    })
+
+            // system_blocks: from Anthropic-format request with inline cache_control
+            if (chatRequest.system_blocks?.length > 0) {
+                for (const block of chatRequest.system_blocks) {
+                    if (block.text) system.push({ text: block.text });
+                    if (block.cache_control?.type === 'ephemeral') {
+                        system.push({ cachePoint: { type: 'default' } });
+                    }
                 }
-            });
-            // console.log("system", JSON.stringify(system, null, 2) );
-            if (pcFields.indexOf("system") >= 0) {
-                system.push({
-                    "cachePoint": {
-                        "type": "default"
+            } else {
+                // OpenAI-format system messages (no inline cache_control)
+                systemMessages.forEach(msg => {
+                    if (msg.content && (typeof msg.content === "string")) {
+                        system.push({ text: msg.content });
+                    } else if (msg.content && Array.isArray(msg.content)) {
+                        msg.content.forEach((msg2: any) => {
+                            msg2?.text && system.push({ text: msg2.text });
+                        })
                     }
                 });
+            }
+
+            // config-based prompt cache (backward compat)
+            if (pcFields.indexOf("system") >= 0) {
+                system.push({ cachePoint: { type: 'default' } });
             }
             rtn.system = system;
         }
@@ -1111,14 +1134,20 @@ class MessageConverter {
 
 
         if (tools && tools.length > 0) {
-            xtools = {};
-            xtools = tools.map((tool: any) => ({
-                toolSpec: {
-                    name: tool.function?.name,
-                    description: tool.function?.description || 'No description provided',
-                    inputSchema: { json: tool.function?.parameters }
+            xtools = [];
+            for (const tool of tools) {
+                xtools.push({
+                    toolSpec: {
+                        name: tool.function?.name,
+                        description: tool.function?.description || 'No description provided',
+                        inputSchema: { json: tool.function?.parameters }
+                    }
+                });
+                // Inline cache_control on tool definition → cachePoint after toolSpec
+                if (tool.cache_control?.type === 'ephemeral') {
+                    xtools.push({ cachePoint: { type: 'default' } });
                 }
-            }));
+            }
         }
 
         if (tool_choice) {

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -348,6 +348,9 @@ class Provider {
         if (tool_choice !== undefined) req.tool_choice = tool_choice;
         if (body.stop_sequences?.length) req.stop = body.stop_sequences;
 
+        // Carry system_blocks for cache_control support (Anthropic array system)
+        if (Array.isArray(body.system)) req.system_blocks = body.system;
+
         return req;
     }
 


### PR DESCRIPTION
## Summary

- Adds `BEDROCK_BETA_BLOCKLIST` — a compile-time constant listing Anthropic beta headers that Bedrock does **not** support and must be stripped before forwarding requests
- Reads the client's `anthropic-beta` header in both `complete()` and `chat()` entry points and passes it into `toPayload()`
- Merges client-supplied beta values with the auto-injected model-specific features, deduplicating via `Set<string>` and filtering out blocklisted values
- Maps Anthropic `cache_control` blocks to Bedrock `cachePoint` so prompt-caching requests from Claude Code and the Anthropic SDK are forwarded correctly

## Blocked headers (stripped before sending to Bedrock)

| Header | Reason |
|---|---|
| `files-api-2025-04-14` | Bedrock has no Files API |
| `computer-use-2025-01-24` | Not supported on Bedrock Converse API |
| `prompt-caching-scope-2026-01-05` | Bedrock handles caching differently |
| `redact-thinking-2026-02-12` | Anthropic-internal only |
| `advisor-tool-2026-03-01` | Anthropic-internal only |

## Passed-through headers (forwarded to Bedrock)

Headers **not** in the blocklist (e.g. `interleaved-thinking-2025-05-14`, `output-128k-2025-02-19`, `token-efficient-tools-2025-02-19`, `context-1m-2025-08-07`) are forwarded as-is, merged with the model-specific auto-injected features.

## Motivation

Claude Code and other Anthropic SDK clients automatically attach `anthropic-beta` headers to every request. Without this filtering, unsupported headers reach Bedrock and cause `ValidationException` errors. This change makes the connector transparently compatible with Claude Code out of the box.

## Test plan

- [ ] Send a request with `anthropic-beta: files-api-2025-04-14` — verify it is stripped and request succeeds
- [ ] Send a request with `anthropic-beta: interleaved-thinking-2025-05-14` — verify it is forwarded to Bedrock
- [ ] Send a request with multiple beta values (comma-separated) — verify blocklisted ones are stripped, others pass through
- [ ] Verify model-specific auto-injection still works (e.g. `claude-3-7-sonnet` gets `output-128k-2025-02-19`)
- [ ] Verify no duplicate beta values when client sends a header already in the auto-inject list

🤖 Generated with [Claude Code](https://claude.com/claude-code)