### PR TITLE
fix: address cache_control/beta-header passthrough review issues

### DIFF
--- a/src/entity/chat_request.ts
+++ b/src/entity/chat_request.ts
@@ -20,6 +20,9 @@ interface ChatRequest {
     max_completion_tokens?: number;
     temperature?: number;
     top_p?: number;
+    /** Raw Anthropic-format system blocks (set when body.system is an array).
+     *  Carries inline cache_control so toPayload can emit cachePoint entries. */
+    system_blocks?: Array<{ type: string; text?: string; cache_control?: { type: string } }>;
     [key: string]: any; // refined parameters
 }
 

--- a/src/providers/bedrock_converse.ts
+++ b/src/providers/bedrock_converse.ts
@@ -1027,7 +1027,21 @@ class MessageConverter {
 
             // 处理普通 user 消息
             if (message.role === 'user') {
-                message.content = await this.convertContent(message.content);
+                if (Array.isArray(message.content)) {
+                    // Preserve cache_control: convert each block individually,
+                    // injecting a cachePoint after any block that carries cache_control.
+                    const converted: any[] = [];
+                    for (const item of message.content) {
+                        const block = await this.convertConverseSingleType(item);
+                        if (block) converted.push(block);
+                        if (item.cache_control?.type === 'ephemeral') {
+                            converted.push({ cachePoint: { type: 'default' } });
+                        }
+                    }
+                    message.content = converted.length > 0 ? converted : [{ text: '.' }];
+                } else {
+                    message.content = await this.convertContent(message.content);
+                }
                 newMessages.push(message);
                 continue;
             }
@@ -1092,24 +1106,33 @@ class MessageConverter {
 
         const rtn: any = { messages: alternatingMessages, inferenceConfig, additionalModelRequestFields };
 
-        if (systemMessages.length > 0) {
+        if (systemMessages.length > 0 || chatRequest.system_blocks?.length > 0) {
             const system = [];
-            systemMessages.forEach(msg => {
-                if (msg.content && (typeof msg.content === "string")) {
-                    system.push({ text: msg.content });
-                } else if (msg.content && Array.isArray(msg.content)) {
-                    msg.content.forEach((msg2: any) => {
-                        msg2?.text && system.push({ text: msg2.text });
-                    })
+
+            // system_blocks: from Anthropic-format request with inline cache_control
+            if (chatRequest.system_blocks?.length > 0) {
+                for (const block of chatRequest.system_blocks) {
+                    if (block.text) system.push({ text: block.text });
+                    if (block.cache_control?.type === 'ephemeral') {
+                        system.push({ cachePoint: { type: 'default' } });
+                    }
                 }
-            });
-            // console.log("system", JSON.stringify(system, null, 2) );
-            if (pcFields.indexOf("system") >= 0) {
-                system.push({
-                    "cachePoint": {
-                        "type": "default"
+            } else {
+                // OpenAI-format system messages (no inline cache_control)
+                systemMessages.forEach(msg => {
+                    if (msg.content && (typeof msg.content === "string")) {
+                        system.push({ text: msg.content });
+                    } else if (msg.content && Array.isArray(msg.content)) {
+                        msg.content.forEach((msg2: any) => {
+                            msg2?.text && system.push({ text: msg2.text });
+                        })
                     }
                 });
+            }
+
+            // config-based prompt cache (backward compat)
+            if (pcFields.indexOf("system") >= 0) {
+                system.push({ cachePoint: { type: 'default' } });
             }
             rtn.system = system;
         }
@@ -1119,14 +1142,20 @@ class MessageConverter {
 
 
         if (tools && tools.length > 0) {
-            xtools = {};
-            xtools = tools.map((tool: any) => ({
-                toolSpec: {
-                    name: tool.function?.name,
-                    description: tool.function?.description || 'No description provided',
-                    inputSchema: { json: tool.function?.parameters }
+            xtools = [];
+            for (const tool of tools) {
+                xtools.push({
+                    toolSpec: {
+                        name: tool.function?.name,
+                        description: tool.function?.description || 'No description provided',
+                        inputSchema: { json: tool.function?.parameters }
+                    }
+                });
+                // Inline cache_control on tool definition → cachePoint after toolSpec
+                if (tool.cache_control?.type === 'ephemeral') {
+                    xtools.push({ cachePoint: { type: 'default' } });
                 }
-            }));
+            }
         }
 
         if (tool_choice) {

--- a/src/providers/bedrock_converse.ts
+++ b/src/providers/bedrock_converse.ts
@@ -2,6 +2,13 @@ import { ChatRequest, ResponseData } from "../entity/chat_request"
 import {
     BedrockRuntimeClient, ConverseStreamCommand, ConverseCommand
 } from "@aws-sdk/client-bedrock-runtime";
+import { NodeHttpHandler } from "@smithy/node-http-handler";
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import helper from "../util/helper";
+// import config from "../config";
+import WebResponse from "../util/response";
+import AbstractProvider from "./abstract_provider";
+import AnthropicResponse from '../util/anthropic_response';
 
 /**
  * Anthropic beta headers that Bedrock does NOT support and must be stripped
@@ -20,13 +27,6 @@ const BEDROCK_BETA_BLOCKLIST: ReadonlySet<string> = new Set([
     // Advisor tool – Anthropic-internal
     "advisor-tool-2026-03-01",
 ]);
-import { NodeHttpHandler } from "@smithy/node-http-handler";
-import { HttpsProxyAgent } from 'https-proxy-agent';
-import helper from "../util/helper";
-// import config from "../config";
-import WebResponse from "../util/response";
-import AbstractProvider from "./abstract_provider";
-import AnthropicResponse from '../util/anthropic_response';
 
 /**
 * BedrockConverse Provider uses boto3-converse api to invoke LLM models and support function calling.
@@ -820,7 +820,10 @@ class MessageConverter {
                 }
             }
         }
-        return contentItem;
+        // Strip Anthropic-only fields (e.g. cache_control) that Bedrock does not
+        // accept — forwarding them would cause a ValidationException.
+        const { cache_control, ...rest } = contentItem;
+        return rest;
     }
 
 
@@ -1060,6 +1063,7 @@ class MessageConverter {
 
             // 处理普通 user 消息
             if (message.role === 'user') {
+                let newContent: any;
                 if (Array.isArray(message.content)) {
                     // Preserve cache_control: convert each block individually,
                     // injecting a cachePoint after any block that carries cache_control.
@@ -1071,11 +1075,13 @@ class MessageConverter {
                             converted.push({ cachePoint: { type: 'default' } });
                         }
                     }
-                    message.content = converted.length > 0 ? converted : [{ text: '.' }];
+                    newContent = converted.length > 0 ? converted : [{ text: '.' }];
                 } else {
-                    message.content = await this.convertContent(message.content);
+                    newContent = await this.convertContent(message.content);
                 }
-                newMessages.push(message);
+                // Clone to avoid mutating the original chatRequest.messages array
+                // (important for retry scenarios where toPayload may be called again).
+                newMessages.push({ ...message, content: newContent });
                 continue;
             }
         }

--- a/src/providers/bedrock_converse.ts
+++ b/src/providers/bedrock_converse.ts
@@ -2,6 +2,24 @@ import { ChatRequest, ResponseData } from "../entity/chat_request"
 import {
     BedrockRuntimeClient, ConverseStreamCommand, ConverseCommand
 } from "@aws-sdk/client-bedrock-runtime";
+
+/**
+ * Anthropic beta headers that Bedrock does NOT support and must be stripped
+ * before forwarding requests.  Claude Code (and other Anthropic SDK clients)
+ * send these automatically; passing them to Bedrock causes validation errors.
+ */
+const BEDROCK_BETA_BLOCKLIST: ReadonlySet<string> = new Set([
+    // Files API – Bedrock has no equivalent
+    "files-api-2025-04-14",
+    // Computer-use – not supported on Bedrock Converse
+    "computer-use-2025-01-24",
+    // Prompt-caching scope flag – Bedrock handles caching differently
+    "prompt-caching-scope-2026-01-05",
+    // Redact-thinking – Anthropic-internal, not a Bedrock feature
+    "redact-thinking-2026-02-12",
+    // Advisor tool – Anthropic-internal
+    "advisor-tool-2026-03-01",
+]);
 import { NodeHttpHandler } from "@smithy/node-http-handler";
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import helper from "../util/helper";
@@ -87,7 +105,8 @@ export default class BedrockConverse extends AbstractProvider {
 
     async complete(chatRequest: ChatRequest, session_id: string, ctx: any) {
         await this.init();
-        const payload = await this.chatMessageConverter.toPayload(chatRequest, this.modelData.config);
+        const clientBetaHeader = ctx.headers?.["anthropic-beta"] as string | undefined;
+        const payload = await this.chatMessageConverter.toPayload(chatRequest, this.modelData.config, clientBetaHeader);
         if (chatRequest.model_id) {
             payload["modelId"] = chatRequest.model_id;
         } else {
@@ -127,7 +146,8 @@ export default class BedrockConverse extends AbstractProvider {
             // console.log(this.modelData.config)
         }
 
-        const payload = await this.chatMessageConverter.toPayload(chatRequest, this.modelData.config);
+        const clientBetaHeader = ctx.headers?.["anthropic-beta"] as string | undefined;
+        const payload = await this.chatMessageConverter.toPayload(chatRequest, this.modelData.config, clientBetaHeader);
         if (chatRequest.model_id) {
             payload["modelId"] = chatRequest.model_id;
         } else {
@@ -804,7 +824,7 @@ class MessageConverter {
     }
 
 
-    async toPayload(chatRequest: ChatRequest, config: any): Promise<any> {
+    async toPayload(chatRequest: ChatRequest, config: any, clientBetaHeader?: string): Promise<any> {
 
         let maxTokens = config && config.maxTokens;
         if (!maxTokens || isNaN(maxTokens)) {
@@ -901,18 +921,31 @@ class MessageConverter {
                     delete inferenceConfig.topP;
                 }
             }
-            const anthropicBetaFeatures = [];
+            // Auto-inject model-specific beta features required by Bedrock.
+            const anthropicBetaFeatures = new Set<string>();
             if (config.modelId.includes("anthropic.claude-3-7-sonnet")) {
-                anthropicBetaFeatures.push("output-128k-2025-02-19")
-                anthropicBetaFeatures.push("token-efficient-tools-2025-02-19")
+                anthropicBetaFeatures.add("output-128k-2025-02-19");
+                anthropicBetaFeatures.add("token-efficient-tools-2025-02-19");
             }
             if (config.modelId.includes("anthropic.claude-sonnet-4")) {
-                anthropicBetaFeatures.push("context-1m-2025-08-07")
+                anthropicBetaFeatures.add("context-1m-2025-08-07");
             }
             if (config.modelId.includes("anthropic.claude-sonnet-4-5")) {
-                anthropicBetaFeatures.push("context-management-2025-06-27")
+                anthropicBetaFeatures.add("context-management-2025-06-27");
             }
-            additionalModelRequestFields["anthropic_beta"] = anthropicBetaFeatures;
+
+            // Merge client-supplied anthropic-beta header values, filtering out
+            // anything in BEDROCK_BETA_BLOCKLIST (Bedrock-unsupported headers).
+            if (clientBetaHeader) {
+                for (const value of clientBetaHeader.split(",")) {
+                    const trimmed = value.trim();
+                    if (trimmed && !BEDROCK_BETA_BLOCKLIST.has(trimmed)) {
+                        anthropicBetaFeatures.add(trimmed);
+                    }
+                }
+            }
+
+            additionalModelRequestFields["anthropic_beta"] = Array.from(anthropicBetaFeatures);
         }
         //First element must be user message
         const newMessages = [];

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -351,6 +351,9 @@ class Provider {
         // Carry thinking param from Anthropic request body
         if (body.thinking !== undefined) req.thinking = body.thinking;
 
+        // Carry system_blocks for cache_control support (Anthropic array system)
+        if (Array.isArray(body.system)) req.system_blocks = body.system;
+
         return req;
     }
 

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -245,11 +245,15 @@ class Provider {
         const messages: any[] = [];
 
         // system prompt → system message
+        // When body.system is an array, system_blocks carries the raw blocks
+        // (with cache_control) and toPayload reads them directly.  Only push a
+        // flattened role:'system' message for the plain-string case so that the
+        // two paths don't both fire and leave dead content in messages[].
         if (body.system) {
-            const systemContent = typeof body.system === 'string'
-                ? body.system
-                : body.system.map((b: any) => b.text || '').join('');
-            messages.push({ role: 'system', content: systemContent });
+            if (typeof body.system === 'string') {
+                messages.push({ role: 'system', content: body.system });
+            }
+            // Array form is handled via req.system_blocks below.
         }
 
         // Convert Anthropic messages → OpenAI-style messages


### PR DESCRIPTION
## Summary

- `anthropic-beta` header passthrough from client → Bedrock, filtered against a compile-time `BEDROCK_BETA_BLOCKLIST` of unsupported headers
- `cache_control` → `cachePoint` translation for user message blocks, tool definitions, and system blocks
- Model-specific beta feature auto-injection via `Set` (deduplication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)